### PR TITLE
Add client config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,28 @@ puts response.to_hash()
 
 n.b. the keys of the response hash will always be symbols. 
 
+## Configuration
+
+You may optionally supply a config argument with your API key:
+
+```ruby
+require 'button'
+
+client = Button::Client.new('sk-XXX', {
+  hostname: 'api.testsite.com',
+  port: 3000,
+  secure: false,
+  timeout: 5 # seconds
+})
+```
+
+The supported options are as follows:
+
+* `hostname`: Defaults to `api.usebutton.com`.
+* `port`: Defaults to `443` if `config.secure`, else defaults to `80`.
+* `secure`: Whether or not to use HTTPS. Defaults to True.  **N.B: Button's API is only exposed through HTTPS. This option is provided purely as a convenience for testing and development.**
+* `timeout`: The time in seconds that may elapse before network requests abort. Defaults to `nil`.
+
 ## Resources
 
 We currently expose only one resource to manage, `Orders`. 

--- a/lib/button/client.rb
+++ b/lib/button/client.rb
@@ -16,14 +16,28 @@ module Button
   # puts client.orders.get("btnorder-XXX")
   #
   class Client
-    def initialize(api_key)
+    def initialize(api_key, config = {})
       if api_key.nil? || api_key.empty?
         raise ButtonClientError, NO_API_KEY_MESSAGE
       end
 
-      @orders = Orders.new(api_key)
+      config_with_defaults = merge_defaults(config)
+
+      @orders = Orders.new(api_key, config_with_defaults)
+    end
+
+    def merge_defaults(config)
+      secure = config.fetch(:secure, true)
+
+      return {
+        secure: secure,
+        timeout: config.fetch(:timeout, nil),
+        hostname: config.fetch(:hostname, 'api.usebutton.com'),
+        port: config.fetch(:port, secure ? 443 : 80)
+      }
     end
 
     attr_reader :orders
+    private :merge_defaults
   end
 end

--- a/lib/button/resources/resource.rb
+++ b/lib/button/resources/resource.rb
@@ -24,14 +24,21 @@ module Button
   # end
   #
   class Resource
-    HOST = 'api.usebutton.com'.freeze
-    PORT = 443
     USER_AGENT = "Button/#{Button::VERSION} ruby/#{RUBY_VERSION}".freeze
 
-    def initialize(api_key)
+    def initialize(api_key, config)
       @api_key = api_key
-      @http = Net::HTTP.new(HOST, PORT)
-      @http.use_ssl = true
+      @config = config
+      @http = Net::HTTP.new(config[:hostname], config[:port])
+      @http.use_ssl = config[:secure]
+
+      if not config[:timeout].nil?
+        @http.read_timeout = config[:timeout]
+      end
+    end
+
+    def timeout
+      @http.read_timeout
     end
 
     # Performs an HTTP GET at the provided path.
@@ -96,6 +103,7 @@ module Button
       raise ButtonClientError, "Invalid response: #{parsed}"
     end
 
+    attr_accessor :config
     private :api_request, :process_response
   end
 end

--- a/lib/button/version.rb
+++ b/lib/button/version.rb
@@ -1,3 +1,3 @@
 module Button
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.1.0'.freeze
 end

--- a/lib/button/version.rb
+++ b/lib/button/version.rb
@@ -1,3 +1,3 @@
 module Button
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 end

--- a/test/button/client_test.rb
+++ b/test/button/client_test.rb
@@ -19,4 +19,31 @@ class ClientTest < Test::Unit::TestCase
     client = Button::Client.new('sk-XXX')
     assert_respond_to(client, :orders)
   end
+
+  def test_sets_default_config_parameters
+    client = Button::Client.new('sk-XXX')
+    assert_equal(client.orders.config, {
+      hostname: 'api.usebutton.com',
+      port: 443,
+      secure: true,
+      timeout: nil
+    })
+  end
+
+  def test_allows_config_overrides
+    config = {
+      hostname: 'localhost',
+      port: 8080,
+      secure: false,
+      timeout: 20
+    }
+
+    client = Button::Client.new('sk-XXX', config)
+    assert_equal(client.orders.config, config)
+  end
+
+  def test_sets_default_port_properly
+    client = Button::Client.new('sk-XXX', secure: false)
+    assert_equal(client.orders.config[:port], 80)
+  end
 end

--- a/test/button/resources/orders_test.rb
+++ b/test/button/resources/orders_test.rb
@@ -1,6 +1,15 @@
 require File.expand_path('../../../test_helper', __FILE__)
 
 class OrdersTest < Test::Unit::TestCase
+  def setup
+    @orders = Button::Orders.new('sk-XXX', {
+      secure: true,
+      timeout: nil,
+      hostname: 'api.usebutton.com',
+      port: 443
+    })
+  end
+
   def teardown
     WebMock.reset!
   end
@@ -10,7 +19,7 @@ class OrdersTest < Test::Unit::TestCase
       .with(headers: { Authorization: 'Basic c2stWFhYOg==' })
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": { "a": 1 } }')
 
-    response = Button::Orders.new('sk-XXX').get('btnorder-XXX')
+    response = @orders.get('btnorder-XXX')
     assert_equal(response.a, 1)
   end
 
@@ -19,7 +28,7 @@ class OrdersTest < Test::Unit::TestCase
       .with(body: '{"a":1}', headers: { Authorization: 'Basic c2stWFhYOg==' })
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": { "a": 1 } }')
 
-    response = Button::Orders.new('sk-XXX').create(a: 1)
+    response = @orders.create(a: 1)
     assert_equal(response.a, 1)
   end
 
@@ -28,7 +37,7 @@ class OrdersTest < Test::Unit::TestCase
       .with(body: '{"a":1}', headers: { Authorization: 'Basic c2stWFhYOg==' })
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": { "a": 1 } }')
 
-    response = Button::Orders.new('sk-XXX').update('btnorder-XXX', a: 1)
+    response = @orders.update('btnorder-XXX', a: 1)
     assert_equal(response.a, 1)
   end
 
@@ -37,7 +46,7 @@ class OrdersTest < Test::Unit::TestCase
       .with(headers: { Authorization: 'Basic c2stWFhYOg==' })
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": null }')
 
-    response = Button::Orders.new('sk-XXX').delete('btnorder-XXX')
+    response = @orders.delete('btnorder-XXX')
     assert_equal(response.to_hash, {})
   end
 end


### PR DESCRIPTION
### Description

Adding support for a `config` hash which may be supplied as an optional 2nd argument to the `Button::Client#new`.  This adds support for configurable hostname, port, timeout, and protocol.  This should be entirely backwards compatible. 