### PR TITLE
Fix User-Agent error (set header instead of append)

### DIFF
--- a/lib/button/resources/resource.rb
+++ b/lib/button/resources/resource.rb
@@ -71,10 +71,10 @@ module Button
 
     def api_request(request, body = nil)
       request.basic_auth(@api_key, '')
-      request.add_field('User-Agent', USER_AGENT)
+      request['User-Agent'] = USER_AGENT
 
       if !body.nil? && body.respond_to?(:to_json)
-        request.add_field('Content-Type', 'application/json')
+        request['Content-Type'] = 'application/json'
         request.body = body.to_json
       end
 

--- a/test/button/resources/orders_test.rb
+++ b/test/button/resources/orders_test.rb
@@ -11,7 +11,7 @@ class OrdersTest < Test::Unit::TestCase
 
     @headers = {
       'Authorization' => 'Basic c2stWFhYOg==',
-      'User-Agent' => 'Button/1.1.0 ruby/1.9.3'
+      'User-Agent' => Button::Resource::USER_AGENT
     }
   end
 

--- a/test/button/resources/orders_test.rb
+++ b/test/button/resources/orders_test.rb
@@ -8,6 +8,11 @@ class OrdersTest < Test::Unit::TestCase
       hostname: 'api.usebutton.com',
       port: 443
     })
+
+    @headers = {
+      'Authorization' => 'Basic c2stWFhYOg==',
+      'User-Agent' => 'Button/1.1.0 ruby/1.9.3'
+    }
   end
 
   def teardown
@@ -16,7 +21,7 @@ class OrdersTest < Test::Unit::TestCase
 
   def test_get
     stub_request(:get, 'https://api.usebutton.com/v1/order/btnorder-XXX')
-      .with(headers: { Authorization: 'Basic c2stWFhYOg==' })
+      .with(headers: @headers)
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": { "a": 1 } }')
 
     response = @orders.get('btnorder-XXX')
@@ -25,7 +30,7 @@ class OrdersTest < Test::Unit::TestCase
 
   def test_create
     stub_request(:post, 'https://api.usebutton.com/v1/order')
-      .with(body: '{"a":1}', headers: { Authorization: 'Basic c2stWFhYOg==' })
+      .with(body: '{"a":1}', headers: @headers)
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": { "a": 1 } }')
 
     response = @orders.create(a: 1)
@@ -34,7 +39,7 @@ class OrdersTest < Test::Unit::TestCase
 
   def test_update
     stub_request(:post, 'https://api.usebutton.com/v1/order/btnorder-XXX')
-      .with(body: '{"a":1}', headers: { Authorization: 'Basic c2stWFhYOg==' })
+      .with(body: '{"a":1}', headers: @headers)
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": { "a": 1 } }')
 
     response = @orders.update('btnorder-XXX', a: 1)
@@ -43,7 +48,7 @@ class OrdersTest < Test::Unit::TestCase
 
   def test_delete
     stub_request(:delete, 'https://api.usebutton.com/v1/order/btnorder-XXX')
-      .with(headers: { Authorization: 'Basic c2stWFhYOg==' })
+      .with(headers: @headers)
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": null }')
 
     response = @orders.delete('btnorder-XXX')

--- a/test/button/resources/resource_test.rb
+++ b/test/button/resources/resource_test.rb
@@ -8,6 +8,11 @@ class ResourceTest < Test::Unit::TestCase
       hostname: 'api.usebutton.com',
       port: 443
     })
+
+    @headers = {
+      'Authorization' => 'Basic c2stWFhYOg==',
+      'User-Agent' => 'Button/1.1.0 ruby/1.9.3'
+    }
   end
 
   def teardown
@@ -16,6 +21,7 @@ class ResourceTest < Test::Unit::TestCase
 
   def test_raises_with_empty_response
     stub_request(:get, 'https://api.usebutton.com/v1/bloop')
+      .with(headers: @headers)
       .to_return(status: 200, body: '')
 
     assert_raises(Button::ButtonClientError) do
@@ -25,6 +31,7 @@ class ResourceTest < Test::Unit::TestCase
 
   def test_raises_with_nil_response
     stub_request(:get, 'https://api.usebutton.com/v1/bloop')
+      .with(headers: @headers)
       .to_return(status: 200, body: nil)
 
     assert_raises(Button::ButtonClientError) do
@@ -34,6 +41,7 @@ class ResourceTest < Test::Unit::TestCase
 
   def test_raises_with_invalid_json_response
     stub_request(:get, 'https://api.usebutton.com/v1/bloop')
+      .with(headers: @headers)
       .to_return(status: 200, body: 'invalid json')
 
     assert_raises(Button::ButtonClientError) do
@@ -43,6 +51,7 @@ class ResourceTest < Test::Unit::TestCase
 
   def test_raises_with_a_server_error
     stub_request(:get, 'https://api.usebutton.com/v1/bloop')
+      .with(headers: @headers)
       .to_return(status: 404, body: '{ "meta": { "status": "error" }, "error": { "message": "bloop" } }')
 
     assert_raises(Button::ButtonClientError.new('bloop')) do
@@ -52,6 +61,7 @@ class ResourceTest < Test::Unit::TestCase
 
   def test_raises_with_an_unknown_status_error
     stub_request(:get, 'https://api.usebutton.com/v1/bloop')
+      .with(headers: @headers)
       .to_return(status: 404, body: '{ "meta": { "status": "wat" }, "error": { "message": "bloop" } }')
 
     assert_raises(Button::ButtonClientError.new('Unknown status: wat')) do
@@ -61,6 +71,7 @@ class ResourceTest < Test::Unit::TestCase
 
   def test_raises_if_receives_unknown_error_response
     stub_request(:get, 'https://api.usebutton.com/v1/bloop')
+      .with(headers: @headers)
       .to_return(status: 404, body: '{}')
 
     assert_raises(Button::ButtonClientError) do
@@ -70,6 +81,7 @@ class ResourceTest < Test::Unit::TestCase
     WebMock.reset!
 
     stub_request(:get, 'https://api.usebutton.com/v1/bloop')
+      .with(headers: @headers)
       .to_return(status: 404, body: '{ "meta": "wat" }')
 
     assert_raises(Button::ButtonClientError) do
@@ -79,6 +91,7 @@ class ResourceTest < Test::Unit::TestCase
     WebMock.reset!
 
     stub_request(:get, 'https://api.usebutton.com/v1/bloop')
+      .with(headers: @headers)
       .to_return(status: 404, body: '{ "meta": { "status": "error" }, "error": "wat" }')
 
     assert_raises(Button::ButtonClientError) do
@@ -90,6 +103,7 @@ class ResourceTest < Test::Unit::TestCase
 
   def test_gets_a_resource
     stub_request(:get, 'https://api.usebutton.com/v1/bloop')
+      .with(headers: @headers)
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": { "a": 1 } }')
 
     response = @resource.api_get('/v1/bloop')
@@ -98,6 +112,7 @@ class ResourceTest < Test::Unit::TestCase
 
   def test_posts_a_resource
     stub_request(:post, 'https://api.usebutton.com/v1/bloop')
+      .with(headers: @headers)
       .with(body: '{"a":1}')
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": { "a": 1 } }')
 
@@ -107,6 +122,7 @@ class ResourceTest < Test::Unit::TestCase
 
   def test_deletes_a_resource
     stub_request(:delete, 'https://api.usebutton.com/v1/bloop/1')
+      .with(headers: @headers)
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": null }')
 
     response = @resource.api_delete('/v1/bloop/1')
@@ -115,6 +131,7 @@ class ResourceTest < Test::Unit::TestCase
 
   def test_uses_config
     stub_request(:get, 'http://localhost:8080/v1/bloop')
+      .with(headers: @headers)
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": { "a": 1 } }')
 
     resource = Button::Resource.new('sk-XXX', {

--- a/test/button/resources/resource_test.rb
+++ b/test/button/resources/resource_test.rb
@@ -11,7 +11,7 @@ class ResourceTest < Test::Unit::TestCase
 
     @headers = {
       'Authorization' => 'Basic c2stWFhYOg==',
-      'User-Agent' => 'Button/1.1.0 ruby/1.9.3'
+      'User-Agent' => Button::Resource::USER_AGENT
     }
   end
 


### PR DESCRIPTION
### Description

We were setting the `User-Agent` and `Content-Type` headers via the `add_field` method.  Unfortunately, these methods were appending the first argument to any existing values set on that header.  This meant the actual `User-Agent` being reported was `Ruby, Button/1.1.0 ruby/2.3.0`, not `Button/1.1.0 ruby/2.3.0`.  Using `[]=` syntax corrects for this.  Tests have been updated to detect this error. 

A followup to this PR will be cutting a `v1.1.1` release. 