### PR TITLE
Integrate Linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,17 @@
+Metrics/AbcSize:
+  Max: 40
+
+Metrics/MethodLength:
+  Max: 80
+
+Metrics/ClassLength:
+  Max: 200
+
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+Metrics/PerceivedComplexity:
+  Max: 10
+
+Metrics/LineLength:
+  Max: 120

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 group :development do
   gem 'addressable', '2.4.0'
   gem 'rake', '10.4.2'
-  gem 'rubocop', '0.46.0'
+  gem 'rubocop', '0.41.2'
   gem 'test-unit', '3.1.5'
   gem 'webmock', '2.1.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,9 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'rake', '10.4.2'
-  gem 'test-unit', '3.1.5'
   gem 'addressable', '2.4.0'
+  gem 'rake', '10.4.2'
+  gem 'rubocop', '0.46.0'
+  gem 'test-unit', '3.1.5'
   gem 'webmock', '2.1.0'
 end

--- a/README.md
+++ b/README.md
@@ -144,14 +144,14 @@ puts response
 
 Utils houses generic helpers useful in a Button Integration.
 
-### #is_webhook_authentic
+### #webhook_authentic?
 
 Used to verify that requests sent to a webhook endpoint are from Button and that their payload can be trusted. Returns `true` if a webhook request body matches the sent signature and `false` otherwise. See [Webhook Security](https://www.usebutton.com/developers/webhooks/#security) for more details.
 
 ```ruby
 require 'button'
 
-Button::Utils::is_webhook_authentic(
+Button::Utils::webhook_authentic?(
   ENV['WEBHOOK_SECRET'],
   request_body,
   request_headers.fetch('X-Button-Signature')
@@ -163,4 +163,5 @@ Button::Utils::is_webhook_authentic(
 * Building the gem: `gem build button.gemspec`
 * Installing locally: `gem install ./button-X.Y.Z.gem`
 * Installing development dependencies: `bundle install`
+* Running linter: `rake lint`
 * Running tests: `bundle exec rake`

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,11 @@
 require 'rake/testtask'
+require 'rubocop/rake_task'
 
-task(default: [:test])
+task default: [:test]
+task test: [:unit, :lint]
 
-Rake::TestTask.new do |t|
+Rake::TestTask.new(:unit) do |t|
   t.pattern = './test/**/*_test.rb'
 end
+
+RuboCop::RakeTask.new(:lint)

--- a/bin/console
+++ b/bin/console
@@ -1,5 +1,8 @@
 #!/usr/bin/env ruby
 
+lib = File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
 require 'irb'
 require "#{File.expand_path('../../lib', __FILE__)}/button.rb"
 

--- a/lib/button/client.rb
+++ b/lib/button/client.rb
@@ -2,7 +2,7 @@ require 'button/resources/orders'
 require 'button/errors'
 
 NO_API_KEY_MESSAGE = 'Must provide a Button API key.  Find yours at '\
-  'https://app.usebutton.com/settings/organization'
+  'https://app.usebutton.com/settings/organization'.freeze
 
 module Button
   # Client is the top-level interface for the Button API.  It exposes one
@@ -29,7 +29,7 @@ module Button
     def merge_defaults(config)
       secure = config.fetch(:secure, true)
 
-      return {
+      {
         secure: secure,
         timeout: config.fetch(:timeout, nil),
         hostname: config.fetch(:hostname, 'api.usebutton.com'),

--- a/lib/button/resources/resource.rb
+++ b/lib/button/resources/resource.rb
@@ -32,9 +32,8 @@ module Button
       @http = Net::HTTP.new(config[:hostname], config[:port])
       @http.use_ssl = config[:secure]
 
-      if not config[:timeout].nil?
-        @http.read_timeout = config[:timeout]
-      end
+      return if config[:timeout].nil?
+      @http.read_timeout = config[:timeout]
     end
 
     def timeout

--- a/lib/button/utils.rb
+++ b/lib/button/utils.rb
@@ -1,12 +1,14 @@
 require 'openssl'
 
 module Button
+  # Generally handy functions for various aspects of a Button integration
+  #
   module Utils
     # Used to verify that requests sent to a webhook endpoint are from Button
     # and that their payload can be trusted. Returns true if a webhook request
     # body matches the sent signature and false otherwise.
     #
-    def is_webhook_authentic(webhook_secret, request_body, sent_signature)
+    def webhook_authentic?(webhook_secret, request_body, sent_signature)
       computed_signature = OpenSSL::HMAC.hexdigest(
         OpenSSL::Digest.new('sha256'),
         webhook_secret,
@@ -16,6 +18,6 @@ module Button
       sent_signature == computed_signature
     end
 
-    module_function :is_webhook_authentic
+    module_function :webhook_authentic?
   end
 end

--- a/test/button/client_test.rb
+++ b/test/button/client_test.rb
@@ -22,12 +22,13 @@ class ClientTest < Test::Unit::TestCase
 
   def test_sets_default_config_parameters
     client = Button::Client.new('sk-XXX')
-    assert_equal(client.orders.config, {
+    assert_equal(
+      client.orders.config,
       hostname: 'api.usebutton.com',
       port: 443,
       secure: true,
       timeout: nil
-    })
+    )
   end
 
   def test_allows_config_overrides

--- a/test/button/resources/orders_test.rb
+++ b/test/button/resources/orders_test.rb
@@ -2,12 +2,13 @@ require File.expand_path('../../../test_helper', __FILE__)
 
 class OrdersTest < Test::Unit::TestCase
   def setup
-    @orders = Button::Orders.new('sk-XXX', {
+    @orders = Button::Orders.new(
+      'sk-XXX',
       secure: true,
       timeout: nil,
       hostname: 'api.usebutton.com',
       port: 443
-    })
+    )
 
     @headers = {
       'Authorization' => 'Basic c2stWFhYOg==',

--- a/test/button/resources/resource_test.rb
+++ b/test/button/resources/resource_test.rb
@@ -2,12 +2,13 @@ require File.expand_path('../../../test_helper', __FILE__)
 
 class ResourceTest < Test::Unit::TestCase
   def setup
-    @resource = Button::Resource.new('sk-XXX', {
+    @resource = Button::Resource.new(
+      'sk-XXX',
       secure: true,
       timeout: nil,
       hostname: 'api.usebutton.com',
       port: 443
-    })
+    )
 
     @headers = {
       'Authorization' => 'Basic c2stWFhYOg==',
@@ -134,12 +135,13 @@ class ResourceTest < Test::Unit::TestCase
       .with(headers: @headers)
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": { "a": 1 } }')
 
-    resource = Button::Resource.new('sk-XXX', {
+    resource = Button::Resource.new(
+      'sk-XXX',
       secure: false,
       timeout: 1989,
       hostname: 'localhost',
       port: 8080
-    })
+    )
 
     response = resource.api_get('/v1/bloop')
     assert_equal(resource.timeout, 1989)

--- a/test/button/utils_test.rb
+++ b/test/button/utils_test.rb
@@ -1,22 +1,22 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class UtilsTest < Test::Unit::TestCase
-  def test_is_webhook_authentic
+  def test_webhook_authentic
     signature = '79a3a5291c94340ff0058a6319063757'\
                 '68d706357ee86826c3c692e6b9aa6817'
     payload = '{ "a": 1 }'
 
-    assert_false(Button::Utils.is_webhook_authentic('secret', payload, 'XXX'))
-    assert_true(Button::Utils.is_webhook_authentic('secret', payload, signature))
-    assert_false(Button::Utils.is_webhook_authentic('secret?', payload, signature))
-    assert_false(Button::Utils.is_webhook_authentic('secret', '{ "a": 2 }', signature))
+    assert_false(Button::Utils.webhook_authentic?('secret', payload, 'XXX'))
+    assert_true(Button::Utils.webhook_authentic?('secret', payload, signature))
+    assert_false(Button::Utils.webhook_authentic?('secret?', payload, signature))
+    assert_false(Button::Utils.webhook_authentic?('secret', '{ "a": 2 }', signature))
   end
 
-  def test_is_webhook_authentic_unicode_payload
+  def test_webhook_authentic_unicode_payload
     signature = '3040cf48ab225ca539c1d23841175bc2'\
                 '2e565cdb0975bd690ecaeca2c39dfcf7'
     payload = "{ \"a\": \u1f60e }"
 
-    assert_true(Button::Utils.is_webhook_authentic('secret', payload, signature))
+    assert_true(Button::Utils.webhook_authentic?('secret', payload, signature))
   end
 end


### PR DESCRIPTION
This PR is a grab-bag of lint fun! It:

1. Adds `.rubocop.yml` to define project-specific lint overrides
2. Adds `rake lint` to our CI builds
3. Fixes `bin/console` to properly open a shell with the gem
4. Updates the codebase per our `.rubocop.yml`

Pushing this before we release `1.2.0` given the breaking API change (`#is_webhook_authentic` renamed to `#webhook_authentic?`)