### PR TITLE
Add accounts resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ rescue Button::ButtonClientError => error
   puts error
 end
 
-puts response 
+puts response
 # => Button::Response(button_order_id: btnorder-XXX, total: 60, ... )
 
 puts response.button_order_id
@@ -98,7 +98,7 @@ response = client.orders.create({
   btn_ref: 'srctok-XXX'
 })
 
-puts response 
+puts response
 # => Button::Response(button_order_id: btnorder-XXX, total: 50, ... )
 ```
 
@@ -111,9 +111,10 @@ client = Button::Client.new('sk-XXX')
 
 response = client.orders.get('btnorder-XXX')
 
-puts response 
+puts response
 # => Button::Response(button_order_id: btnorder-XXX, total: 50, ... )
 ```
+
 ##### Update
 
 ```ruby
@@ -123,7 +124,7 @@ client = Button::Client.new('sk-XXX')
 
 response = client.orders.update('btnorder-XXX', total: 60)
 
-puts response 
+puts response
 # => Button::Response(button_order_id: btnorder-XXX, total: 60, ... )
 ```
 
@@ -139,6 +140,82 @@ response = client.orders.delete('btnorder-XXX')
 puts response
 # => Button::Response()
 ```
+
+### Accounts
+
+##### all
+
+```ruby
+require 'button'
+
+client = Button::Client.new('sk-XXX')
+
+response = client.accounts.all
+
+puts response
+# => Button::Response(2 elements)
+```
+
+##### transactions
+
+_n.b. transactions is a paged endpoint.  Take care to inspect `response.next_cursor` in case there's more data to be read._
+
+Along with the required account id, you may also pass the following optional arguments as a Hash as the second argument:
+
+* `:cursor` (String): An API cursor to fetch a specific set of results.
+* `:start` (ISO-8601 datetime String): Fetch transactions after this time.
+* `:end` (ISO-8601 datetime String): Fetch transactions before this time.
+
+```ruby
+require 'button'
+
+client = Button::Client.new('sk-XXX')
+
+response = client.accounts.transactions('acc-XXX')
+cursor = response.next_cursor
+
+puts response
+# => Button::Response(75 elements)
+
+# Unpage all results
+#
+while !cursor.nil? do
+  response = client.accounts.transactions('acc-XXX', cursor: cursor)
+  cursor = response.next_cursor
+end
+```
+
+## Response
+
+The Button::Response class will be returned by all API methods.  It is used to read the respone data as well as collect any meta data about the response, like potential next and previous cursors to more data in a paged endpoint.
+
+### Methods
+
+#### data
+
+returns the underlying response data
+
+```ruby
+require 'button'
+
+client = Button::Client.new('sk-XXX')
+
+response = client.accounts.all
+
+puts response
+# => Button::Response(2 elements)
+
+puts response.data
+# => [ { ... }, { ... } ]
+```
+
+#### next_cursor
+
+For any paged resource, `#next_cursor` will return a cursor to supply for the next page of results.  If `#next_cursor` returns `nil`, then there are no more results.
+
+#### prev_cursor
+
+For any paged resource, `#prev_cursor` will return a cursor to supply for the previous page of results.  If `#prev_cursor` returns `nil`, then there are no more results, err.. backwards.
 
 ## Utils
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ end
 
 ## Response
 
-The Button::Response class will be returned by all API methods.  It is used to read the respone data as well as collect any meta data about the response, like potential next and previous cursors to more data in a paged endpoint.
+An instance of the `Button::Response` class will be returned by all API methods.  It is used to read the response data as well as collect any meta data about the response, like potential next and previous cursors to more data in a paged endpoint.
 
 ### Methods
 

--- a/lib/button/client.rb
+++ b/lib/button/client.rb
@@ -1,4 +1,5 @@
 require 'button/resources/orders'
+require 'button/resources/accounts'
 require 'button/errors'
 
 NO_API_KEY_MESSAGE = 'Must provide a Button API key.  Find yours at '\
@@ -24,6 +25,7 @@ module Button
       config_with_defaults = merge_defaults(config)
 
       @orders = Orders.new(api_key, config_with_defaults)
+      @accounts = Accounts.new(api_key, config_with_defaults)
     end
 
     def merge_defaults(config)
@@ -37,7 +39,7 @@ module Button
       }
     end
 
-    attr_reader :orders
+    attr_reader :orders, :accounts
     private :merge_defaults
   end
 end

--- a/lib/button/resources/accounts.rb
+++ b/lib/button/resources/accounts.rb
@@ -1,0 +1,39 @@
+require 'button/resources/resource'
+
+module Button
+  # https://www.usebutton.com/developers/api-reference/
+  #
+  class Accounts < Resource
+    def path(account_id = nil)
+      return "/v1/affiliation/accounts/#{account_id}/transactions" if account_id
+      '/v1/affiliation/accounts'
+    end
+
+    # Gets a list of available accounts
+    #
+    # @return [Button::Response] the API response
+    #
+    def all
+      api_get(path)
+    end
+
+    # Gets a list of transactions for an account
+    #
+    # @param [String] account_id the account id to look up transactions for
+    # @option [String] cursor the account id to look up transactions for
+    # @option [ISO-8601 datetime String] start The start date to filter
+    #   transactions
+    # @option [ISO-8601 datetime String] end The end date to filter
+    #   transactions
+    # @return [Button::Response] the API response
+    #
+    def transactions(account_id, opts = {})
+      query = {}
+      query['cursor'] = opts[:cursor] if opts[:cursor]
+      query['start'] = opts[:start] if opts[:start]
+      query['end'] = opts[:end] if opts[:end]
+
+      api_get(path(account_id), query)
+    end
+  end
+end

--- a/test/button/resources/accounts_test.rb
+++ b/test/button/resources/accounts_test.rb
@@ -1,0 +1,70 @@
+require File.expand_path('../../../test_helper', __FILE__)
+
+class Accounts < Test::Unit::TestCase
+  def setup
+    @accounts = Button::Accounts.new(
+      'sk-XXX',
+      secure: true,
+      timeout: nil,
+      hostname: 'api.usebutton.com',
+      port: 443
+    )
+
+    @headers = {
+      'Authorization' => 'Basic c2stWFhYOg==',
+      'User-Agent' => Button::Resource::USER_AGENT
+    }
+  end
+
+  def teardown
+    WebMock.reset!
+  end
+
+  def test_all
+    stub_request(:get, 'https://api.usebutton.com/v1/affiliation/accounts')
+      .with(headers: @headers)
+      .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "objects": [{ "a": 1 }] }')
+
+    response = @accounts.all
+    assert_equal(response.data.size, 1)
+    assert_equal(response.data[0][:a], 1)
+  end
+
+  def test_transactions
+    body = '{ "meta": { "status": "ok", "prev": "https://bloop.net?cursor=1989",'\
+           ' "next": "https://bloop.net?cursor=1991" }, "objects": [{ "a": 1 }] }'
+    stub_request(:get, 'https://api.usebutton.com/v1/affiliation/accounts/acc-1/transactions')
+      .with(headers: @headers)
+      .to_return(status: 200, body: body)
+
+    response = @accounts.transactions('acc-1')
+    assert_equal(response.data.size, 1)
+    assert_equal(response.data[0][:a], 1)
+    assert_equal(response.prev_cursor, '1989')
+    assert_equal(response.next_cursor, '1991')
+  end
+
+  def test_transactions_with_cursor
+    body = '{ "meta": { "status": "ok", "prev": "https://bloop.net?cursor=1989",'\
+           ' "next": "https://bloop.net?cursor=1991" }, "objects": [{ "a": 1 }] }'
+    stub_request(:get, 'https://api.usebutton.com/v1/affiliation/accounts/acc-1/transactions?cursor=1989')
+      .with(headers: @headers)
+      .to_return(status: 200, body: body)
+
+    response = @accounts.transactions('acc-1', cursor: '1989')
+    assert_equal(response.data.size, 1)
+    assert_equal(response.data[0][:a], 1)
+  end
+
+  def test_transactions_with_start_and_end
+    body = '{ "meta": { "status": "ok", "prev": "https://bloop.net?cursor=1989",'\
+           ' "next": "https://bloop.net?cursor=1991" }, "objects": [{ "a": 1 }] }'
+    stub_request(:get, 'https://api.usebutton.com/v1/affiliation/accounts/acc-1/transactions?end=2014-01-01&start=2012-01-01')
+      .with(headers: @headers)
+      .to_return(status: 200, body: body)
+
+    response = @accounts.transactions('acc-1', start: '2012-01-01', end: '2014-01-01')
+    assert_equal(response.data.size, 1)
+    assert_equal(response.data[0][:a], 1)
+  end
+end

--- a/test/button/resources/orders_test.rb
+++ b/test/button/resources/orders_test.rb
@@ -26,7 +26,7 @@ class OrdersTest < Test::Unit::TestCase
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": { "a": 1 } }')
 
     response = @orders.get('btnorder-XXX')
-    assert_equal(response.a, 1)
+    assert_equal(response.data[:a], 1)
   end
 
   def test_create
@@ -35,7 +35,7 @@ class OrdersTest < Test::Unit::TestCase
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": { "a": 1 } }')
 
     response = @orders.create(a: 1)
-    assert_equal(response.a, 1)
+    assert_equal(response.data[:a], 1)
   end
 
   def test_update
@@ -44,7 +44,7 @@ class OrdersTest < Test::Unit::TestCase
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": { "a": 1 } }')
 
     response = @orders.update('btnorder-XXX', a: 1)
-    assert_equal(response.a, 1)
+    assert_equal(response.data[:a], 1)
   end
 
   def test_delete
@@ -53,6 +53,6 @@ class OrdersTest < Test::Unit::TestCase
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": null }')
 
     response = @orders.delete('btnorder-XXX')
-    assert_equal(response.to_hash, {})
+    assert_equal(response.data, nil)
   end
 end

--- a/test/button/resources/resource_test.rb
+++ b/test/button/resources/resource_test.rb
@@ -108,7 +108,16 @@ class ResourceTest < Test::Unit::TestCase
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": { "a": 1 } }')
 
     response = @resource.api_get('/v1/bloop')
-    assert_equal(response.a, 1)
+    assert_equal(response.data[:a], 1)
+  end
+
+  def test_gets_a_resource_with_query
+    stub_request(:get, 'https://api.usebutton.com/v1/bloop?a=1&b=bloop')
+      .with(headers: @headers)
+      .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": { "a": 1 } }')
+
+    response = @resource.api_get('/v1/bloop', 'a' => 1, 'b' => 'bloop')
+    assert_equal(response.data[:a], 1)
   end
 
   def test_posts_a_resource
@@ -118,7 +127,7 @@ class ResourceTest < Test::Unit::TestCase
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": { "a": 1 } }')
 
     response = @resource.api_post('/v1/bloop', a: 1)
-    assert_equal(response.a, 1)
+    assert_equal(response.data[:a], 1)
   end
 
   def test_deletes_a_resource
@@ -127,7 +136,7 @@ class ResourceTest < Test::Unit::TestCase
       .to_return(status: 200, body: '{ "meta": { "status": "ok" }, "object": null }')
 
     response = @resource.api_delete('/v1/bloop/1')
-    assert_equal(response.to_hash, {})
+    assert_equal(response.data, nil)
   end
 
   def test_uses_config
@@ -145,6 +154,6 @@ class ResourceTest < Test::Unit::TestCase
 
     response = resource.api_get('/v1/bloop')
     assert_equal(resource.timeout, 1989)
-    assert_equal(response.a, 1)
+    assert_equal(response.data[:a], 1)
   end
 end

--- a/test/button/response_test.rb
+++ b/test/button/response_test.rb
@@ -1,24 +1,56 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class ResponseTest < Test::Unit::TestCase
-  def test_method_lookups
-    response = Button::Response.new(a: 1, b: 'two')
-    assert_equal(response.a, 1)
-    assert_equal(response.b, 'two')
+  def test_meta
+    meta = {
+      prev: 'https://bloop.net/dork?bleep&cursor=1989',
+      next: 'https://bloop.net/dork?bleep&cursor=1991'
+    }
 
-    assert_raises(NoMethodError) do
-      response.c
-    end
+    response = Button::Response.new(meta, {})
+    assert_equal(response.prev_cursor, '1989')
+    assert_equal(response.next_cursor, '1991')
   end
 
-  def test_to_hash
-    hash = { a: 1, b: 'two' }
-    response = Button::Response.new(hash)
-    assert_equal(response.to_hash, a: 1, b: 'two')
+  def test_data
+    data = { a: 1, b: 'two' }
+    response = Button::Response.new({}, data)
+    assert_equal(response.data, a: 1, b: 'two')
   end
 
   def test_to_s
-    response = Button::Response.new(a: 1, b: 'two')
-    assert_equal(response.to_s, 'Button::Response(a: 1, b: two)')
+    assert_equal(
+      Button::Response.new({}, a: 1, b: 'two').to_s,
+      'Button::Response(a: 1, b: two)'
+    )
+
+    assert_equal(
+      Button::Response.new({}, a: 1, b: nil).to_s,
+      'Button::Response(a: 1, b: nil)'
+    )
+
+    assert_equal(
+      Button::Response.new({}, {}).to_s,
+      'Button::Response()'
+    )
+
+    assert_equal(
+      Button::Response.new({}, [1, 2, 3]).to_s,
+      'Button::Response(3 elements)'
+    )
+
+    assert_equal(
+      Button::Response.new({}, []).to_s,
+      'Button::Response(0 elements)'
+    )
+  end
+
+  def test_cursor_parsing
+    assert_equal(Button::Response.format_cursor('bloop'), nil)
+    assert_equal(Button::Response.format_cursor('bloop.net'), nil)
+    assert_equal(Button::Response.format_cursor('https://bloop.net'), nil)
+    assert_equal(Button::Response.format_cursor('////'), nil)
+    assert_equal(Button::Response.format_cursor('https://bloop.net/bleep?two=three'), nil)
+    assert_equal(Button::Response.format_cursor('https://bloop.net/bleep?two=three&cursor=pup'), 'pup')
   end
 end


### PR DESCRIPTION
This pull request adds support for fetching `accounts` and `transactions`.  

Because it involves a restructuring of the `Button::Response` class, It is not backwards-compatible and will require a major version bump with the next release.